### PR TITLE
Add direct link to Bintray page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 JD-Core is a JAVA decompiler written in JAVA.
 
 - Java Decompiler project home page:
-[http://java-decompiler.github.io](http://java-decompiler.github.io)
+[http://java-decompiler.github.io](https://java-decompiler.github.io)
 - JD-Core source code:
 [https://github.com/java-decompiler/jd-core](https://github.com/java-decompiler/jd-core)
 - JCenter Maven repository:
-[https://jcenter.bintray.com/](https://jcenter.bintray.com/)
+[https://jcenter.bintray.com/](https://bintray.com/java-decompiler/maven/org.jd%3Ajd-core/_latestVersion)
 
 ## Description
 JD-Core is a standalone JAVA library containing the JAVA decompiler of


### PR DESCRIPTION
This makes it easier to get the correct group and artifact id and version.
You could also add a Bintray badge, see the "Latest Version Badge" button on Bintray.