### PR TITLE
Fix PlainTextPrinter creating incorrect Unicode escape sequences

### DIFF
--- a/src/test/java/org/jd/core/v1/printer/PlainTextPrinter.java
+++ b/src/test/java/org/jd/core/v1/printer/PlainTextPrinter.java
@@ -35,9 +35,11 @@ public class PlainTextPrinter implements Printer {
         indentationCount = 0;
     }
 
+    @Override
     public String toString() { return sb.toString(); }
 
     // --- Printer --- //
+    @Override
     public void start(int maxLineNumber, int majorVersion, int minorVersion) {
         this.indentationCount = 0;
 
@@ -55,8 +57,10 @@ public class PlainTextPrinter implements Printer {
         }
     }
 
+    @Override
     public void end() {}
 
+    @Override
     public void printText(String text) {
         if (escapeUnicodeCharacters) {
             for(int i=0, len=text.length(); i<len; i++) {
@@ -82,24 +86,32 @@ public class PlainTextPrinter implements Printer {
         }
     }
 
+    @Override
     public void printNumericConstant(String constant) { sb.append(constant); }
 
+    @Override
     public void printStringConstant(String constant, String ownerInternalName) { printText(constant); }
 
+    @Override
     public void printKeyword(String keyword) { sb.append(keyword); }
 
+    @Override
     public void printDeclaration(int type, String internalTypeName, String name, String descriptor) { printText(name); }
 
+    @Override
     public void printReference(int type, String internalTypeName, String name, String descriptor, String ownerInternalName) { printText(name); }
 
+    @Override
     public void indent() {
         this.indentationCount++;
     }
+    @Override
     public void unindent() {
         if (this.indentationCount > 0)
             this.indentationCount--;
     }
 
+    @Override
     public void startLine(int lineNumber) {
         printLineNumber(lineNumber);
 
@@ -107,10 +119,12 @@ public class PlainTextPrinter implements Printer {
             sb.append(TAB);
     }
 
+    @Override
     public void endLine() {
         sb.append(NEWLINE);
     }
 
+    @Override
     public void extraLine(int count) {
         while (count-- > 0) {
             printLineNumber(0);
@@ -118,8 +132,10 @@ public class PlainTextPrinter implements Printer {
         }
     }
 
+    @Override
     public void startMarker(int type) {}
 
+    @Override
     public void endMarker(int type) {}
 
     protected void printLineNumber(int lineNumber) {

--- a/src/test/java/org/jd/core/v1/printer/PlainTextPrinter.java
+++ b/src/test/java/org/jd/core/v1/printer/PlainTextPrinter.java
@@ -60,6 +60,19 @@ public class PlainTextPrinter implements Printer {
     @Override
     public void end() {}
 
+    private static char hexChar(int v, int halfByteIndex) {
+        int halfByte = (v >> halfByteIndex * 4) & 15;
+        return halfByte <= 9 ? (char)('0' + halfByte) : (char)('A' + halfByte - 10);
+    }
+
+    private static void writeUnicodeEscape(StringBuilder sb, char c) {
+        sb.append("\\u");
+
+        for (int index = 3; index >= 0; index--) {
+            sb.append(hexChar(c, index));
+        }
+    }
+
     @Override
     public void printText(String text) {
         if (escapeUnicodeCharacters) {
@@ -69,16 +82,7 @@ public class PlainTextPrinter implements Printer {
                 if (c < 128) {
                     sb.append(c);
                 } else {
-                    int h = (c >> 24);
-
-                    sb.append("\\u");
-                    sb.append((h <= 9) ? (h + '0') : (h + 'A'));
-                    h = (c >> 16) & 255;
-                    sb.append((h <= 9) ? (h + '0') : (h + 'A'));
-                    h = (c >> 8) & 255;
-                    sb.append((h <= 9) ? (h + '0') : (h + 'A'));
-                    h = (c) & 255;
-                    sb.append((h <= 9) ? (h + '0') : (h + 'A'));
+                    writeUnicodeEscape(sb, c);
                 }
             }
         } else {


### PR DESCRIPTION
PlainTextPrinter creates Unicode escape sequences incorrectly:
- It shifts the code point value by 8 (= a full byte, two hex chars) instead of 4 (= half byte, one hex char)
- It calls `StringBuilder.append(int)` which adds the string representation of the int instead of considering it as code point
- It does not subtract 10 when calculating `h + 'A'`

This pull request fixes this. It can be verified using:
```
PlainTextPrinter printer = new PlainTextPrinter(true);
printer.printText("\uABCD");
System.out.print(printer.toString());
```