### PR TITLE
Throw exception when class to decompile cannot be loaded

### DIFF
--- a/src/main/java/org/jd/core/v1/service/deserializer/classfile/ClassFileDeserializer.java
+++ b/src/main/java/org/jd/core/v1/service/deserializer/classfile/ClassFileDeserializer.java
@@ -25,10 +25,21 @@ public class ClassFileDeserializer {
     protected static final int[] EMPTY_INT_ARRAY = new int[0];
 
     public ClassFile loadClassFile(Loader loader, String internalTypeName) throws Exception {
-        return innerLoadClassFile(loader, internalTypeName);
+        ClassFile classFile = innerLoadClassFile(loader, internalTypeName);
+
+        if (classFile == null) {
+            throw new IllegalArgumentException("Class '" + internalTypeName + "' could not be loaded");
+        }
+        else {
+            return classFile;
+        }
     }
 
-    public ClassFile innerLoadClassFile(Loader loader, String internalTypeName) throws Exception {
+    private ClassFile innerLoadClassFile(Loader loader, String internalTypeName) throws Exception {
+        if (!loader.canLoad(internalTypeName)) {
+            return null;
+        }
+
         byte[] data = loader.load(internalTypeName);
 
         if (data == null) {

--- a/src/test/java/org/jd/core/v1/ClassFileDeserializerTest.java
+++ b/src/test/java/org/jd/core/v1/ClassFileDeserializerTest.java
@@ -8,6 +8,9 @@
 package org.jd.core.v1;
 
 import junit.framework.TestCase;
+
+import org.jd.core.v1.api.loader.Loader;
+import org.jd.core.v1.api.loader.LoaderException;
 import org.jd.core.v1.loader.ZipLoader;
 import org.jd.core.v1.model.classfile.ClassFile;
 import org.jd.core.v1.model.classfile.Field;
@@ -17,12 +20,36 @@ import org.jd.core.v1.model.classfile.attribute.ElementValuePrimitiveType;
 import org.jd.core.v1.model.classfile.constant.ConstantInteger;
 import org.jd.core.v1.model.classfile.constant.ConstantUtf8;
 import org.jd.core.v1.model.message.Message;
+import org.jd.core.v1.service.deserializer.classfile.ClassFileDeserializer;
 import org.jd.core.v1.service.deserializer.classfile.DeserializeClassFileProcessor;
 import org.junit.Test;
 
 import java.io.InputStream;
 
 public class ClassFileDeserializerTest extends TestCase {
+    @Test
+    public void testMissingClass() throws Exception {
+        class NoOpLoader implements Loader {
+            @Override
+            public boolean canLoad(String internalName) {
+                return false;
+            }
+
+            @Override
+            public byte[] load(String internalName) throws LoaderException {
+                fail("Loader cannot load anything");
+                return null;
+            }
+        }
+
+        ClassFileDeserializer deserializer = new ClassFileDeserializer();
+        try {
+            deserializer.loadClassFile(new NoOpLoader(), "DoesNotExist");
+            fail("Expected exception");
+        }
+        // Expecting exception because class cannot be loaded
+        catch (IllegalArgumentException expected) { }
+    }
 
     @Test
     public void testAnnotatedClass() throws Exception {


### PR DESCRIPTION
Previously a not descriptive `NullPointerException` was thrown, now an `IllegalArgumentException` is thrown instead (maybe a different exception type would fit better?).
Also `ClassFileDeserializer` would try to load classes without checking if they can be loaded.