### PR TITLE
Remove recursive and redundant equals methods

### DIFF
--- a/src/main/java/org/jd/core/v1/model/javafragment/ImportsFragment.java
+++ b/src/main/java/org/jd/core/v1/model/javafragment/ImportsFragment.java
@@ -111,11 +111,9 @@ public class ImportsFragment extends FlexibleFragment implements JavaFragment {
     }
 
     protected static class ImportCountComparator implements Comparator<Import> {
+        @Override
         public int compare(Import tr1, Import tr2) {
             return tr2.getCounter() - tr1.getCounter();
-        }
-        public boolean equals(Object obj) {
-            return this.equals(obj);
         }
     }
 }

--- a/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphLoopReducer.java
+++ b/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphLoopReducer.java
@@ -720,10 +720,5 @@ public class ControlFlowGraphLoopReducer {
         public int compare(Loop loop1, Loop loop2) {
             return loop1.getMembers().size() - loop2.getMembers().size();
         }
-
-        @Override
-        public boolean equals(Object other) {
-            return this==other;
-        }
     }
 }

--- a/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphMaker.java
+++ b/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphMaker.java
@@ -588,10 +588,5 @@ public class ControlFlowGraphMaker {
                 comp = ce1.getEndPc() - ce2.getEndPc();
             return comp;
         }
-
-        @Override
-        public boolean equals(Object other) {
-            return this==other;
-        }
     }
 }

--- a/src/main/java/org/jd/core/v1/service/tokenizer/javafragmenttotoken/visitor/TokenizeJavaFragmentVisitor.java
+++ b/src/main/java/org/jd/core/v1/service/tokenizer/javafragmenttotoken/visitor/TokenizeJavaFragmentVisitor.java
@@ -517,11 +517,9 @@ public class TokenizeJavaFragmentVisitor implements JavaFragmentVisitor {
     }
 
     protected static class ImportNameComparator implements Comparator<ImportsFragment.Import> {
+        @Override
         public int compare(ImportsFragment.Import tr1, ImportsFragment.Import tr2) {
             return tr1.getQualifiedName().compareTo(tr2.getQualifiedName());
-        }
-        public boolean equals(Object obj) {
-            return this.equals(obj);
         }
     }
 


### PR DESCRIPTION
Equals methods calling themselves would cause infinite recursion.
Equals methods checking `this == obj` are the same as the default implementation and are therefore redundant.