### PR TITLE
Fix deprecated expression in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,24 +5,24 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
-    testCompile 'commons-codec:commons-codec:1.13'
-    testCompile 'org.apache.commons:commons-collections4:4.1'
-    testCompile 'org.apache.commons:commons-imaging:1.0-alpha1'
-    testCompile 'org.apache.commons:commons-lang3:3.9'
-    testCompile 'com.jakewharton:disklrucache:2.0.2'
-    testCompile 'com.squareup:javapoet:1.11.1'
-    testCompile 'com.squareup:javawriter:2.5.1'
-    testCompile 'joda-time:joda-time:2.10.5'
-    testCompile 'org.joda:joda-convert:2.2.1'
-    testCompile 'org.jsoup:jsoup:1.12.1'
-    testCompile 'junit:junit:4.12'
-    testCompile 'javax.jms:javax.jms-api:2.0.1'
-    testCompile 'javax.mail:javax.mail-api:1.6.2'
-    testCompile 'com.squareup.mimecraft:mimecraft:1.1.1'
-    testCompile 'org.scribe:scribe:1.3.7'
-    testCompile 'com.sparkjava:spark-core:2.9.1'
-    testCompile 'log4j:log4j:1.2.17'
-    testCompile 'com.google.guava:guava:12.0'
+    testImplementation 'commons-codec:commons-codec:1.13'
+    testImplementation 'org.apache.commons:commons-collections4:4.1'
+    testImplementation 'org.apache.commons:commons-imaging:1.0-alpha1'
+    testImplementation 'org.apache.commons:commons-lang3:3.9'
+    testImplementation 'com.jakewharton:disklrucache:2.0.2'
+    testImplementation 'com.squareup:javapoet:1.11.1'
+    testImplementation 'com.squareup:javawriter:2.5.1'
+    testImplementation 'joda-time:joda-time:2.10.5'
+    testImplementation 'org.joda:joda-convert:2.2.1'
+    testImplementation 'org.jsoup:jsoup:1.12.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'javax.jms:javax.jms-api:2.0.1'
+    testImplementation 'javax.mail:javax.mail-api:1.6.2'
+    testImplementation 'com.squareup.mimecraft:mimecraft:1.1.1'
+    testImplementation 'org.scribe:scribe:1.3.7'
+    testImplementation 'com.sparkjava:spark-core:2.9.1'
+    testImplementation 'log4j:log4j:1.2.17'
+    testImplementation 'com.google.guava:guava:12.0'
 }
 
 version='1.1.4'
@@ -36,7 +36,7 @@ tasks.withType(JavaCompile) {
 
 buildscript {
     repositories {
-        jcenter()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
@@ -44,12 +44,12 @@ buildscript {
 }
 
 repositories {
-    jcenter()
+    gradlePluginPortal()
 }
 
 jar {
     manifest {
-        attributes 'JD-Core-Version': version
+        attributes 'JD-Core-Version': project.jar.archiveVersion
     }
 }
 


### PR DESCRIPTION
This pull request is intended to support gradle 7.x.x by fixing deprecated notations in build.gradle.
 * Migrating testCompile to testImplementation
 * Migrating jcenter to gradlePluginPortal
 * Migrating version to project.jar.archiveVersion in jar section.

Confirmed environment:
Gradle 7.4.2
Build time: 2022-03-31 15:25:29 UTC
Revision: 540473b8118064efcc264694cbcaa4b677f61041

Kotlin: 1.5.31
Groovy: 3.0.9
Ant: Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM: 18.0.1.1 (Homebrew 18.0.1.1+0)
OS: Mac OS X 12.4 aarch64

Note that jd-core-1.1.4.jar is successful to build under build/libs.
